### PR TITLE
Add driver/spi_master.h include to get spi handle type

### DIFF
--- a/include/ice40.h
+++ b/include/ice40.h
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <esp_err.h>
+#include <driver/spi_master.h>
 
 typedef esp_err_t (*ice40_get_done_t)(bool*);
 typedef esp_err_t (*ice40_set_reset_t)(bool);


### PR DESCRIPTION
Without this, any file including ice40.h would need to
include it before ice40.h which is not great. The include
file should be self-sufficient for its own types.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>